### PR TITLE
Add button style to sanitizeWhitelist

### DIFF
--- a/bootstrap-tourist.js
+++ b/bootstrap-tourist.js
@@ -671,7 +671,7 @@
 				}
 
 				var whiteListAdditions = {
-											"button":	["data-role"],
+											"button":	["data-role", "style"],
 											"img":		["style"]
 										};
 


### PR DESCRIPTION
The next button is not removed when using `reflexOnly` with Bootstrap 3.4.x, because the `style` attribute is stripped from the element.

By the way, merging a pull request should be very straightforward. If you want you can click the arrow next to the button and select "Squash and Merge".