### PR TITLE
Fix progresstext not being right-aligned in bootstrap4

### DIFF
--- a/bootstrap-tourist.js
+++ b/bootstrap-tourist.js
@@ -1740,7 +1740,14 @@
 					}
 					else
 					{
+					    if(this._options.framework == "bootstrap3")
+					    {
 						title += '<span class="pull-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
+					    }
+					    if(this._options.framework == "bootstrap4")
+					    {
+						title += '<span class="float-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
+					    }
 					}
 				}
 


### PR DESCRIPTION
Bootstrap4 has [removed](https://getbootstrap.com/docs/4.0/migration/#utilities) the pull-right class, replaced with float-right   This request puts in an extra conditional to ensure that the progress counter doesn't appear to be directly prepended to the step's title.
(And thanks for taking this on - it's proved really useful)