### PR TITLE
Added Reflex option

### DIFF
--- a/bootstrap-tourist.css
+++ b/bootstrap-tourist.css
@@ -30,6 +30,15 @@
   opacity: 0.8;
   filter: alpha(opacity=80);
 }
+.tour-backdrop.left.no-reflex::after {
+  content: '';
+  background-color: transparent;
+  width: 100vw;
+  height: 100vh;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
 .tour-prevent {
   position: absolute;
   z-index: 1102;

--- a/bootstrap-tourist.css
+++ b/bootstrap-tourist.css
@@ -30,15 +30,6 @@
   opacity: 0.8;
   filter: alpha(opacity=80);
 }
-.tour-backdrop.left.no-reflex::after {
-  content: '';
-  background-color: transparent;
-  width: 100vw;
-  height: 100vh;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
 .tour-prevent {
   position: absolute;
   z-index: 1102;

--- a/bootstrap-tourist.js
+++ b/bootstrap-tourist.js
@@ -2232,6 +2232,12 @@
 				$backdropBottom.height(docHeight - elementData.offset.top - elementData.height);
 				$backdropBottom.offset({top: elementData.offset.top + elementData.height, left: 0});
 
+				// check reflex is specifically set to false, if so block the user from interactiving with the element.
+				if (step.reflex === false) 
+				{
+					$backdropLeft.addClass('no-reflex');
+				}
+				
 				$(step.backdropContainer).append($backdropTop);
 				$(step.backdropContainer).append($backdropLeft);
 				$(step.backdropContainer).append($backdropRight);

--- a/bootstrap-tourist.js
+++ b/bootstrap-tourist.js
@@ -1740,13 +1740,13 @@
 					}
 					else
 					{
-						if(this._options.framework == "bootstrap3")
+					    if(this._options.framework == "bootstrap3")
 					    {
-							title += '<span class="pull-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
+						title += '<span class="pull-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
 					    }
 					    if(this._options.framework == "bootstrap4")
 					    {
-							title += '<span class="float-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
+						title += '<span class="float-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
 					    }
 					}
 				}
@@ -2223,7 +2223,7 @@
 				$backdropLeft.offset({top: elementData.offset.top, left: 0});
 
 				var $backdropRight	= $('<div class="tour-backdrop right"></div>');
-				$backdropRight.width(docWidth - (elementData.width + elementData.offset.left));
+				$backdropRight.width(docWidth - elementData.width);
 				$backdropRight.height(elementData.height);
 				$backdropRight.offset({top: elementData.offset.top, left: elementData.offset.left + elementData.width});
 
@@ -2231,12 +2231,6 @@
 				$backdropBottom.width(docWidth);
 				$backdropBottom.height(docHeight - elementData.offset.top - elementData.height);
 				$backdropBottom.offset({top: elementData.offset.top + elementData.height, left: 0});
-
-				// check reflex is specifically set to false, if so block the user from interactiving with the element.
-				if (step.reflex === false) 
-				{
-					$backdropLeft.addClass('no-reflex');
-				}
 
 				$(step.backdropContainer).append($backdropTop);
 				$(step.backdropContainer).append($backdropLeft);

--- a/bootstrap-tourist.js
+++ b/bootstrap-tourist.js
@@ -2216,7 +2216,7 @@
 				$backdropLeft.offset({top: elementData.offset.top, left: 0});
 
 				var $backdropRight	= $('<div class="tour-backdrop right"></div>');
-				$backdropRight.width(docWidth - elementData.width);
+				$backdropRight.width(docWidth - (elementData.width + elementData.offset.left));
 				$backdropRight.height(elementData.height);
 				$backdropRight.offset({top: elementData.offset.top, left: elementData.offset.left + elementData.width});
 

--- a/bootstrap-tourist.js
+++ b/bootstrap-tourist.js
@@ -2232,6 +2232,12 @@
 				$backdropBottom.height(docHeight - elementData.offset.top - elementData.height);
 				$backdropBottom.offset({top: elementData.offset.top + elementData.height, left: 0});
 
+				// check reflex is specifically set to false, if so block the user from doing anything on the page.
+				if (step.reflex === false) 
+				{
+					$backdropLeft.addClass('no-reflex');
+				}
+				
 				$(step.backdropContainer).append($backdropTop);
 				$(step.backdropContainer).append($backdropLeft);
 				$(step.backdropContainer).append($backdropRight);

--- a/bootstrap-tourist.js
+++ b/bootstrap-tourist.js
@@ -2232,12 +2232,12 @@
 				$backdropBottom.height(docHeight - elementData.offset.top - elementData.height);
 				$backdropBottom.offset({top: elementData.offset.top + elementData.height, left: 0});
 
-				// check reflex is specifically set to false, if so block the user from doing anything on the page.
+				// check reflex is specifically set to false, if so block the user from interactiving with the element.
 				if (step.reflex === false) 
 				{
 					$backdropLeft.addClass('no-reflex');
 				}
-				
+
 				$(step.backdropContainer).append($backdropTop);
 				$(step.backdropContainer).append($backdropLeft);
 				$(step.backdropContainer).append($backdropRight);

--- a/bootstrap-tourist.js
+++ b/bootstrap-tourist.js
@@ -1740,7 +1740,14 @@
 					}
 					else
 					{
-						title += '<span class="pull-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
+						if(this._options.framework == "bootstrap3")
+					    {
+							title += '<span class="pull-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
+					    }
+					    if(this._options.framework == "bootstrap4")
+					    {
+							title += '<span class="float-right">' + (i + 1) + '/' + this.getStepCount() + '</span>';
+					    }
 					}
 				}
 


### PR DESCRIPTION
When a step uses backdrop and `reflex: false` then interactions with the element are intentionally blocked.

Leaving reflex undefined still produces the default behavior. 